### PR TITLE
Expose public class in type hints for dumps/loads (#13)

### DIFF
--- a/atoml/__init__.py
+++ b/atoml/__init__.py
@@ -1,4 +1,5 @@
 from .api import (
+    TOMLDocument,
     aot,
     array,
     boolean,

--- a/atoml/api.py
+++ b/atoml/api.py
@@ -38,12 +38,13 @@ def dumps(data: Mapping, sort_keys: bool = False) -> str:
     if not isinstance(data, Container) and isinstance(data, Mapping):
         data = item(dict(data), _sort_keys=sort_keys)
 
-    if hasattr(data, "as_string"):
-        # This condition should be True for all type safe invocations of this
-        # function, since Container implements `as_string`.
+    try:
+        # data should be a `Container` (and therefore implement `as_string`)
+        # for all type safe invocations of this function
         return data.as_string()  # type: ignore[attr-defined]
-
-    raise TypeError(f"Expecting Mapping or TOML Container, {type(data)} given")
+    except Exception as ex:
+        msg = f"Expecting Mapping or TOML Container, {type(data)} given"
+        raise TypeError(msg) from ex
 
 
 def load(fp: IO) -> TOMLDocument:

--- a/atoml/api.py
+++ b/atoml/api.py
@@ -42,7 +42,7 @@ def dumps(data: Mapping, sort_keys: bool = False) -> str:
         # data should be a `Container` (and therefore implement `as_string`)
         # for all type safe invocations of this function
         return data.as_string()  # type: ignore[attr-defined]
-    except Exception as ex:
+    except AttributeError as ex:
         msg = f"Expecting Mapping or TOML Container, {type(data)} given"
         raise TypeError(msg) from ex
 

--- a/atoml/api.py
+++ b/atoml/api.py
@@ -1,5 +1,6 @@
 import datetime as _datetime
 
+from collections.abc import Mapping
 from typing import IO, Tuple
 
 from ._utils import parse_rfc3339
@@ -18,10 +19,10 @@ from .items import (
 from .items import Item as _Item
 from .items import Key, String, Table, Time, Trivia, Whitespace, item
 from .parser import Parser
-from .toml_document import TOMLDocument as _TOMLDocument
+from .toml_document import TOMLDocument
 
 
-def loads(string: str) -> _TOMLDocument:
+def loads(string: str) -> TOMLDocument:
     """
     Parses a string into a TOMLDocument.
 
@@ -30,42 +31,47 @@ def loads(string: str) -> _TOMLDocument:
     return parse(string)
 
 
-def dumps(data: _TOMLDocument, sort_keys: bool = False) -> str:
+def dumps(data: Mapping, sort_keys: bool = False) -> str:
     """
     Dumps a TOMLDocument into a string.
     """
-    if not isinstance(data, _TOMLDocument) and isinstance(data, dict):
-        data = item(data, _sort_keys=sort_keys)
+    if not isinstance(data, Container) and isinstance(data, Mapping):
+        data = item(dict(data), _sort_keys=sort_keys)
 
-    return data.as_string()
+    if hasattr(data, "as_string"):
+        # This condition should be True for all type safe invocations of this
+        # function, since Container implements `as_string`.
+        return data.as_string()  # type: ignore[attr-defined]
+
+    raise TypeError(f"Expecting Mapping or TOML Container, {type(data)} given")
 
 
-def load(fp: IO) -> _TOMLDocument:
+def load(fp: IO) -> TOMLDocument:
     """
     Load toml document from a file-like object.
     """
     return parse(fp.read())
 
 
-def dump(data: _TOMLDocument, fp: IO[str], *, sort_keys: bool = False) -> None:
+def dump(data: Mapping, fp: IO[str], *, sort_keys: bool = False) -> None:
     """
     Dump a TOMLDocument into a writable file stream.
     """
     fp.write(dumps(data, sort_keys=sort_keys))
 
 
-def parse(string: str) -> _TOMLDocument:
+def parse(string: str) -> TOMLDocument:
     """
     Parses a string into a TOMLDocument.
     """
     return Parser(string).parse()
 
 
-def document() -> _TOMLDocument:
+def document() -> TOMLDocument:
     """
     Returns a new TOMLDocument instance.
     """
-    return _TOMLDocument()
+    return TOMLDocument()
 
 
 # Items

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -3,6 +3,7 @@ import json
 import os
 
 from datetime import date, datetime, time
+from types import MappingProxyType
 
 import pytest
 
@@ -150,6 +151,16 @@ def test_a_raw_dict_can_be_dumped():
     s = dumps({"foo": "bar"})
 
     assert s == 'foo = "bar"\n'
+
+
+def test_mapping_types_can_be_dumped():
+    x = MappingProxyType({"foo": "bar"})
+    assert dumps(x) == 'foo = "bar"\n'
+
+
+def test_dumps_weird_object():
+    with pytest.raises(TypeError):
+        dumps(object())
 
 
 def test_dump_to_file_object():


### PR DESCRIPTION
This is a follow up on #13.