### PR TITLE
[Proposal] Remove automatic placement of newlines

### DIFF
--- a/atoml/container.py
+++ b/atoml/container.py
@@ -87,12 +87,6 @@ class Container(MutableMapping, dict):
         if isinstance(item, Table):
             if item.name != key.key:
                 item.display_name = None
-            if self._body and not self._parsed and not item.trivia.indent:
-                item.trivia.indent = "\n"
-
-        if isinstance(item, AoT) and self._body and not self._parsed:
-            if item and "\n" not in item[0].trivia.indent:
-                item[0].trivia.indent = "\n" + item[0].trivia.indent
 
         if key is not None and key in self:
             current_idx = self._map[key]
@@ -196,7 +190,6 @@ class Container(MutableMapping, dict):
                         previous_item = self._body[-1][1]
                         if (
                             not isinstance(previous_item, Whitespace)
-                            and not is_table
                             and "\n" not in previous_item.trivia.trail
                         ):
                             previous_item.trivia.trail += "\n"
@@ -309,7 +302,6 @@ class Container(MutableMapping, dict):
             previous_item = self._body[idx - 1][1]
             if (
                 not isinstance(previous_item, Whitespace)
-                and not isinstance(item, (AoT, Table))
                 and "\n" not in previous_item.trivia.trail
             ):
                 previous_item.trivia.trail += "\n"
@@ -569,8 +561,6 @@ class Container(MutableMapping, dict):
 
         if isinstance(value, Table):
             value.display_name = None
-            # Insert a cosmetic new line for tables
-            value.append(None, Whitespace("\n"))
 
         if isinstance(value, (AoT, Table)) and not isinstance(v, (AoT, Table)):
             # new tables should appear after all non-table values

--- a/atoml/items.py
+++ b/atoml/items.py
@@ -1364,13 +1364,6 @@ class AoT(Item, MutableSequence, list):
                 value.trivia.indent = indent
             else:
                 value.trivia.indent = m.group(1) + indent + m.group(2)
-        prev_table = self._body[index - 1] if 0 < index and length else None
-        next_table = self._body[index + 1] if index < length - 1 else None
-        if not self._parsed:
-            if prev_table and "\n" not in value.trivia.indent:
-                value.trivia.indent = "\n" + value.trivia.indent
-            if next_table and "\n" not in next_table.trivia.indent:
-                next_table.trivia.indent = "\n" + next_table.trivia.indent
         self._body.insert(index, value)
         list.insert(self, index, value)
 
@@ -1394,7 +1387,7 @@ class Null(Item):
     """
 
     def __init__(self) -> None:
-        pass
+        self._trivia = Trivia()  # Required to not break Liskov Substitution Principle
 
     @property
     def discriminant(self) -> int:

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -12,6 +12,7 @@ def test_build_example(example):
     doc.add(nl())
     doc.add("title", "TOML Example")
 
+    doc.add(nl())
     owner = table()
     owner.add("name", "Tom Preston-Werner")
     owner.add("organization", "GitHub")
@@ -21,6 +22,7 @@ def test_build_example(example):
 
     doc.add("owner", owner)
 
+    doc.add(nl())
     database = table()
     database["server"] = "192.168.1.1"
     database["ports"] = [8001, 8001, 8002]
@@ -29,12 +31,12 @@ def test_build_example(example):
 
     doc["database"] = database
 
+    doc.add(nl())
     servers = table()
     servers.add(nl())
     c = comment(
         "You can indent as you please. Tabs or spaces. TOML don't care."
     ).indent(2)
-    c.trivia.trail = ""
     servers.add(c)
     alpha = table()
     servers.append("alpha", alpha)
@@ -42,6 +44,7 @@ def test_build_example(example):
     alpha.add("ip", "10.0.0.1")
     alpha.add("dc", "eqdc10")
 
+    servers.add(nl())
     beta = table()
     servers.append("beta", beta)
     beta.add("ip", "10.0.0.2")
@@ -52,6 +55,7 @@ def test_build_example(example):
 
     doc["servers"] = servers
 
+    doc.add(nl())
     clients = table()
     doc.add("clients", clients)
     clients["data"] = item([["gamma", "delta"], [1, 2]]).comment(
@@ -83,6 +87,7 @@ def test_build_example(example):
     nail["color"] = "gray"
 
     products.append(hammer)
+    hammer.add(nl())
     products.append(nail)
 
     assert content == doc.as_string()
@@ -129,7 +134,6 @@ def test_top_level_keys_are_put_at_the_root_of_the_document():
     expected = """\
 # Comment
 bar = 1
-
 [foo]
 name = "test"
 """

--- a/tests/test_items.py
+++ b/tests/test_items.py
@@ -241,7 +241,6 @@ def test_dicts_are_converted_to_tables_and_keep_order():
         == """[foo]
 bar = "baz"
 abc = 123
-
 [[foo.baz]]
 c = 3
 b = 2
@@ -267,7 +266,6 @@ def test_dicts_are_converted_to_tables_and_are_sorted_if_requested():
         == """[foo]
 abc = 123
 bar = "baz"
-
 [[foo.baz]]
 a = 1
 b = 2
@@ -286,7 +284,6 @@ def test_dicts_with_sub_dicts_are_properly_converted():
         == """[foo]
 float = 3.14
 int = 34
-
 [foo.bar]
 string = "baz"
 """

--- a/tests/test_toml_document.py
+++ b/tests/test_toml_document.py
@@ -277,7 +277,6 @@ name = "Test 1"
         doc.as_string()
         == """[foo]
 a = "b"
-
 [bar]
 name = "Baz"
 
@@ -691,8 +690,6 @@ b = 1
         doc.as_string()
         == """[a]
 a = 1
-
-
 [z]
 b = 1
 """
@@ -710,9 +707,7 @@ c = 3
         doc.as_string()
         == """a = 1
 c = 3
-
 [b]
 foo = "bar"
-
 """
     )


### PR DESCRIPTION
Previously, inserting `Table` and `AoT` items also implied in inserting newline characters preceding these elements.

While this can be considered a nice stylistic choice, it also comes with some draw backs, such as making it very hard to control unintended newlines when editing documents...

An example of this drawback can be find on the following example:
```python
>>> import atoml
>>> example = """\
... [x]
... a = 1
...
... [y]
... b = 2
... """
>>> doc = atoml.loads(example)
>>> doc
{'x': {'a': 1}, 'y': {'b': 2}}
>>> doc['z'] = doc.pop('y')
>>> doc
{'x': {'a': 1}, 'z': {'b': 2}}
>>> print(doc.as_string())
[x]
a = 1

[z]
b = 2
```

(Here we see a duplicated space between the tables `x` and `z`)

The changes implemented here try to make this situation more manageable. By requiring the user to explicitly add newlines, I hope this situation becomes easier to handle.

In the previous example, after the implemented changes we would have:

```python
>>> print(doc.as_string())
[x]
a = 1

[z]
b = 2
```
(Notice no unintended newline between `x` and `z`)

---
An unintended newline might still be introduced by the trailing newline of the entire original TOML text, but that have an easy workaround: `original_string.strip()`.

Please notice the expected value of the test introduced in #28 might require some whitespace adjustment if this proposal/PR is merged.