### PR TITLE
Prevent comments from disappearing when overwriting entries

### DIFF
--- a/atoml/container.py
+++ b/atoml/container.py
@@ -585,8 +585,8 @@ class Container(MutableMapping, dict):
             # Copying trivia
             if not isinstance(value, (Whitespace, AoT)):
                 value.trivia.indent = v.trivia.indent
-                value.trivia.comment_ws = v.trivia.comment_ws
-                value.trivia.comment = v.trivia.comment
+                value.trivia.comment_ws = value.trivia.comment_ws or v.trivia.comment_ws
+                value.trivia.comment = value.trivia.comment or v.trivia.comment
                 value.trivia.trail = v.trivia.trail
             self._body[idx] = (new_key, value)
 

--- a/tests/test_toml_document.py
+++ b/tests/test_toml_document.py
@@ -716,3 +716,33 @@ foo = "bar"
 
 """
     )
+
+
+def test_replace_with_comment():
+    content = 'a = "1"'
+    doc = parse(content)
+    a = atoml.item(int(doc["a"]))
+    a.comment("`a` should be an int")
+    doc["a"] = a
+    expected = "a = 1 # `a` should be an int"
+    assert doc.as_string() == expected
+
+    content = 'a = "1, 2, 3"'
+    doc = parse(content)
+    a = atoml.array()
+    a.comment("`a` should be an array")
+    for x in doc["a"].split(","):
+        a.append(int(x.strip()))
+    doc["a"] = a
+    expected = "a = [1, 2, 3] # `a` should be an array"
+    assert doc.as_string() == expected
+
+    doc = parse(content)
+    a = atoml.inline_table()
+    a.comment("`a` should be an inline-table")
+    for x in doc["a"].split(","):
+        i = int(x.strip())
+        a.append(chr(ord("a") + i - 1), i)
+    doc["a"] = a
+    expected = "a = {a = 1, b = 2, c = 3} # `a` should be an inline-table"
+    assert doc.as_string() == expected


### PR DESCRIPTION
Previously when overwriting entries of a document, some added comments could disappear. For example:

```python
>>> import atoml
>>> example = 'x = "1, 2, 3"'
>>> doc = atoml.loads(example)
>>> x = atoml.array()
>>> x.comment("`x` should be an array")
[]
>>> x.extend(int(i) for i in doc['x'].split(", "))
>>> x.trivia.comment
'# `x` should be an array'
>>> doc['x'] = x
>>> print(doc.as_string())
x = [1, 2, 3]
>>> x.trivia.comment
''
```

Notice that in the example not only the final TOML document does not contain the comment, but also the array object `x` has its "trivia" erased after being inserted.

The changes implemented here try to prevent that from happening:
if the item being inserted has a comment, we should preserve it.